### PR TITLE
require futures only for python < 3.2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,6 @@ setup(
 
     install_requires=[
         'beets>=1.3.7',
-        'futures',
+        'futures;python_version<"3.2"',
     ],
 )


### PR DESCRIPTION
Hi, great plugin! 
Added a fix for #11, so that it can be installed with python 3,
Checked that it works on my machine,

Thanks